### PR TITLE
Anomaly detector

### DIFF
--- a/experiments/fishyscapes.py
+++ b/experiments/fishyscapes.py
@@ -96,9 +96,9 @@ def resynthesis_model(testing_dataset, _run, _log, ours=True,  validation=False)
     fs = bdlb.load(benchmark="fishyscapes", download_and_prepare=False)
     
     if ours:
-        model_id = 'synthesis_boosting'
+        model_id = 'SynBoost'
     else:
-        model_id = 'resynthesis'
+        model_id = 'Resynthesis'
         
     _run.info['{}_anomaly'.format(model_id)] = fs.evaluate(detector.estimator, data)
     

--- a/experiments/fishyscapes.py
+++ b/experiments/fishyscapes.py
@@ -12,6 +12,7 @@ from .utils import ExperimentData
 from fs.data.fsdata import FSData
 from fs.data.utils import load_gdrive_file
 from fs.data.augmentation import crop_multiple
+from driving_uncertainty.test_fishy_torch import AnomalyDetector
 
 ex = Experiment()
 ex.capture_out_filter = apply_backspaces_and_linefeeds
@@ -61,7 +62,46 @@ def saved_model(testing_dataset, model_id, _run, _log, batching=False, validatio
     fs = bdlb.load(benchmark="fishyscapes", download_and_prepare=False)
     _run.info['{}_anomaly'.format(model_id)] = fs.evaluate(eval_func, data)
 
-
+@ex.command
+def resynthesis_model(testing_dataset, _run, _log, ours=True,  validation=False):
+    fsdata = FSData(**testing_dataset)
+    
+    # Hacks because tf.data is shit and we need to translate the dict keys
+    def data_generator():
+        dataset = fsdata.validation_set if validation else fsdata.testset
+        for item in dataset:
+            data = fsdata._get_data(training_format=False, **item)
+            out = {}
+            for m in fsdata.modalities:
+                blob = crop_multiple(data[m])
+                if m == 'rgb':
+                    m = 'image_left'
+                if 'mask' not in fsdata.modalities and m == 'labels':
+                    m = 'mask'
+                out[m] = blob
+            yield out
+    
+    data_types = {}
+    for key, item in fsdata.get_data_description()[0].items():
+        if key == 'rgb':
+            key = 'image_left'
+        if 'mask' not in fsdata.modalities and key == 'labels':
+            key = 'mask'
+        data_types[key] = item
+    
+    data = tf.data.Dataset.from_generator(data_generator, data_types)
+    
+    detector = AnomalyDetector(ours=ours)
+    
+    fs = bdlb.load(benchmark="fishyscapes", download_and_prepare=False)
+    
+    if ours:
+        model_id = 'synthesis_boosting'
+    else:
+        model_id = 'resynthesis'
+        
+    _run.info['{}_anomaly'.format(model_id)] = fs.evaluate(detector.estimator, data)
+    
 if __name__ == '__main__':
     ex.run_commandline()
     os._exit(os.EX_OK)

--- a/experiments/fishyscapes.py
+++ b/experiments/fishyscapes.py
@@ -13,9 +13,6 @@ from fs.data.fsdata import FSData
 from fs.data.utils import load_gdrive_file
 from fs.data.augmentation import crop_multiple
 
-sys.path.insert(0, os.path.join(os.getcwd(), os.path.dirname(os.path.dirname(__file__)), 'driving_uncertainty'))
-from test_fishy_torch import AnomalyDetector
-
 ex = Experiment()
 ex.capture_out_filter = apply_backspaces_and_linefeeds
 ex.observers.append(get_observer())
@@ -68,6 +65,10 @@ def saved_model(testing_dataset, model_id, _run, _log, batching=False, validatio
 
 @ex.command
 def resynthesis_model(testing_dataset, _run, _log, ours=True, validation=False):
+    # added import inside the function to prevent conflicts if this method is not being tested
+    sys.path.insert(0, os.path.join(os.getcwd(), os.path.dirname(os.path.dirname(__file__)), 'driving_uncertainty'))
+    from test_fishy_torch import AnomalyDetector
+    
     fsdata = FSData(**testing_dataset)
     
     # Hacks because tf.data is shit and we need to translate the dict keys


### PR DESCRIPTION
The following pull request is to add compatibility for testing the resynthesis and synthesis boosting models. The import of the necessary module is done inside the function to prevent conflicts if the "driving_uncertainty" module is not in the repository. 

The driving uncertainty repository needs to be cloned in the home of this repository for this to work. You can clone it here: https://github.com/giandbt/driving_uncertainty

The weights for the models can be found here: https://dissimilarity.s3.eu-central-1.amazonaws.com/models.tar. These weights need to be untar inside the driving_uncertainty folder. 

Lastly, to flag "ours" is a boolean to run either SynBoost (True) or Resynthesis (False) 